### PR TITLE
feat: replace bottom nav with sidebar and modernize UI theme

### DIFF
--- a/lib/features/ops/ops_page.dart
+++ b/lib/features/ops/ops_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../ui/components/slash_text.dart';
+import '../../home_shell.dart';
 import 'ops_controller.dart';
 import 'ops_feature_pages.dart';
 import 'ops_models.dart';
@@ -31,6 +32,7 @@ class OpsPage extends ConsumerWidget {
     return Scaffold(
       appBar: AppBar(
         centerTitle: false,
+        leading: const SidebarMenuButton(),
         title: const SlashText('Ops', fontWeight: FontWeight.w700),
         actions: [
           IconButton(

--- a/lib/features/project/project_page.dart
+++ b/lib/features/project/project_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../../ui/components/slash_text.dart';
+import '../../home_shell.dart';
 import '../auth/auth_controller.dart';
 import '../prompt/prompt_service.dart';
 import '../repo/repo_controller.dart';
@@ -203,6 +204,7 @@ class _ProjectPageState extends ConsumerState<ProjectPage> {
     return Scaffold(
       appBar: AppBar(
         centerTitle: false,
+        leading: const SidebarMenuButton(),
         title: const Column(
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/features/prompt/code_page.dart
+++ b/lib/features/prompt/code_page.dart
@@ -7,6 +7,7 @@ import 'package:slash_flutter/ui/components/slash_text.dart';
 
 import '../file_browser/file_browser_controller.dart';
 import '../repo/repo_controller.dart';
+import '../../home_shell.dart';
 import 'code_editor_controller.dart';
 
 class CodeScreen extends ConsumerStatefulWidget {
@@ -1171,6 +1172,7 @@ class _CodeScreenState extends ConsumerState<CodeScreen> {
               : Colors.white,
       elevation: 0,
       surfaceTintColor: Colors.transparent,
+      leading: const SidebarMenuButton(),
       titleSpacing: 12,
       title: Row(
         children: [

--- a/lib/features/prompt/prompt_page.dart
+++ b/lib/features/prompt/prompt_page.dart
@@ -8,6 +8,7 @@ import 'package:slash_flutter/ui/components/slash_toast.dart';
 import 'package:slash_flutter/ui/theme/app_theme_builder.dart';
 import '../../ui/components/slash_text_field.dart';
 import '../../ui/components/slash_button.dart';
+import '../../home_shell.dart';
 import '../repo/repo_controller.dart';
 import '../file_browser/file_browser_controller.dart';
 import 'prompt_controller.dart';
@@ -131,6 +132,7 @@ class _PromptPageState extends ConsumerState<PromptPage> {
         return Scaffold(
           appBar: AppBar(
             backgroundColor: colors.always8B5CF6.withValues(alpha: 0.1),
+            leading: const SidebarMenuButton(),
             title: Image.asset('assets/slash2.png', height: 100),
             centerTitle: false,
             toolbarHeight: 80,

--- a/lib/features/review/pr_page.dart
+++ b/lib/features/review/pr_page.dart
@@ -7,6 +7,7 @@ import 'package:slash_flutter/ui/components/slash_text.dart';
 import 'package:flutter/services.dart';
 
 import '../../services/secure_storage_service.dart';
+import '../../home_shell.dart';
 import '../repo/repo_controller.dart';
 import 'pr_service.dart';
 import 'pr_widgets.dart';
@@ -80,6 +81,7 @@ class PRsPage extends ConsumerWidget {
 
     return Scaffold(
       appBar: AppBar(
+        leading: const SidebarMenuButton(),
         title: const SlashText('Pull Requests', fontWeight: FontWeight.bold),
         centerTitle: false,
         actions: [

--- a/lib/home_shell.dart
+++ b/lib/home_shell.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'common/nav_preferences.dart';
@@ -9,11 +10,49 @@ import 'features/project/project_page.dart';
 import 'features/prompt/prompt_page.dart';
 import 'features/prompt/code_page.dart';
 import 'features/review/pr_page.dart';
-import 'ui/components/slash_text.dart';
 import 'ui/screens/settings_screen.dart';
 
-class HomeShell extends ConsumerWidget {
+// ── Sidebar open signal ───────────────────────────────────────────────────────
+
+/// Increment this from any page to request the sidebar to open.
+final sidebarOpenSignalProvider = StateProvider<int>((ref) => 0);
+
+// ── Shared menu button ────────────────────────────────────────────────────────
+
+/// Drop this into any AppBar's `leading:` to wire up sidebar open.
+class SidebarMenuButton extends ConsumerWidget {
+  const SidebarMenuButton({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return IconButton(
+      icon: const Icon(Icons.menu_rounded),
+      tooltip: 'Menu',
+      onPressed: () {
+        ref.read(sidebarOpenSignalProvider.notifier).update((s) => s + 1);
+        HapticFeedback.lightImpact();
+      },
+    );
+  }
+}
+
+// ── Shell ─────────────────────────────────────────────────────────────────────
+
+const _kSidebarWidth = 280.0;
+
+class HomeShell extends ConsumerStatefulWidget {
   const HomeShell({super.key});
+
+  @override
+  ConsumerState<HomeShell> createState() => _HomeShellState();
+}
+
+class _HomeShellState extends ConsumerState<HomeShell>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _ctrl;
+  late final Animation<Offset> _slideAnim;
+  late final Animation<double> _scrimAnim;
+  bool _isOpen = false;
 
   static Widget _pageForFeature(SlashFeature feature) {
     switch (feature) {
@@ -33,17 +72,55 @@ class HomeShell extends ConsumerWidget {
   }
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  void initState() {
+    super.initState();
+    _ctrl = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 280),
+    );
+    _slideAnim = Tween<Offset>(
+      begin: const Offset(-1, 0),
+      end: Offset.zero,
+    ).animate(CurvedAnimation(parent: _ctrl, curve: Curves.easeOutCubic));
+    _scrimAnim = Tween<double>(begin: 0, end: 0.55).animate(
+      CurvedAnimation(parent: _ctrl, curve: Curves.easeOut),
+    );
+  }
+
+  @override
+  void dispose() {
+    _ctrl.dispose();
+    super.dispose();
+  }
+
+  void _open() {
+    if (_isOpen) return;
+    setState(() => _isOpen = true);
+    _ctrl.forward();
+  }
+
+  void _close() {
+    if (!_isOpen) return;
+    _ctrl.reverse().then((_) {
+      if (mounted) setState(() => _isOpen = false);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Listen for sidebar open requests from any page's menu button.
+    ref.listen(sidebarOpenSignalProvider, (prev, next) {
+      if (next > (prev ?? 0)) _open();
+    });
+
     final auth = ref.watch(authControllerProvider);
     if (!auth.isLoading && !auth.canAccessWorkspace) {
       return const AuthPage();
     }
 
-    final theme = Theme.of(context);
     final activeFeatures = ref.watch(activeNavFeaturesProvider);
     final selectedFeature = ref.watch(selectedFeatureProvider);
 
-    // Clamp selection to a valid feature if the active set changed.
     final safeFeature =
         activeFeatures.contains(selectedFeature)
             ? selectedFeature
@@ -51,130 +128,291 @@ class HomeShell extends ConsumerWidget {
 
     final selectedIndex = activeFeatures.indexOf(safeFeature);
 
-    return Scaffold(
-      body: IndexedStack(
-        index: selectedIndex,
-        children: [for (final f in activeFeatures) _pageForFeature(f)],
-      ),
-      bottomNavigationBar: Padding(
-        padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
-        child: Container(
-          decoration: BoxDecoration(
-            color: theme.colorScheme.surface.withValues(alpha: 0.95),
-            borderRadius: BorderRadius.circular(24),
-            boxShadow: [
-              BoxShadow(
-                color: Colors.black.withValues(alpha: 0.10),
-                blurRadius: 24,
-                offset: const Offset(0, 8),
+    return GestureDetector(
+      // Swipe right to open, swipe left to close.
+      onHorizontalDragEnd: (details) {
+        final v = details.primaryVelocity ?? 0;
+        if (v > 180 && !_isOpen) _open();
+        if (v < -180 && _isOpen) _close();
+      },
+      child: Scaffold(
+        backgroundColor: Theme.of(context).colorScheme.surface,
+        body: Stack(
+          children: [
+            // ── Pages ────────────────────────────────────────────────────
+            IndexedStack(
+              index: selectedIndex,
+              children: [for (final f in activeFeatures) _pageForFeature(f)],
+            ),
+
+            // ── Scrim ─────────────────────────────────────────────────────
+            if (_isOpen)
+              AnimatedBuilder(
+                animation: _scrimAnim,
+                builder: (_, __) => GestureDetector(
+                  onTap: _close,
+                  child: Container(
+                    color: Colors.black.withValues(alpha: _scrimAnim.value),
+                  ),
+                ),
               ),
-            ],
-          ),
-          child: ClipRRect(
-            borderRadius: BorderRadius.circular(24),
-            child: SizedBox(
-              height: 64,
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceAround,
-                children: [
-                  for (final feature in activeFeatures)
-                    _NavBarItem(
-                      feature: feature,
-                      selected: safeFeature == feature,
-                      onTap:
-                          () =>
-                              ref.read(selectedFeatureProvider.notifier).state =
-                                  feature,
-                      theme: theme,
-                    ),
-                ],
+
+            // ── Sidebar ───────────────────────────────────────────────────
+            SlideTransition(
+              position: _slideAnim,
+              child: _Sidebar(
+                activeFeatures: activeFeatures,
+                selectedFeature: safeFeature,
+                onSelect: (f) {
+                  ref.read(selectedFeatureProvider.notifier).state = f;
+                  _close();
+                },
+                onClose: _close,
               ),
             ),
-          ),
+          ],
         ),
       ),
     );
   }
 }
 
-class _NavBarItem extends StatelessWidget {
+// ── Sidebar panel ─────────────────────────────────────────────────────────────
+
+class _Sidebar extends StatelessWidget {
+  final List<SlashFeature> activeFeatures;
+  final SlashFeature selectedFeature;
+  final void Function(SlashFeature) onSelect;
+  final VoidCallback onClose;
+
+  const _Sidebar({
+    required this.activeFeatures,
+    required this.selectedFeature,
+    required this.onSelect,
+    required this.onClose,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final bg = isDark ? const Color(0xFF0B0B0F) : const Color(0xFFF9FAFB);
+    final borderColor =
+        isDark
+            ? const Color(0xFF1E1E28)
+            : const Color(0xFFE5E7EB);
+
+    final navFeatures =
+        activeFeatures.where((f) => f != SlashFeature.settings).toList();
+    final hasSettings = activeFeatures.contains(SlashFeature.settings);
+
+    return Container(
+      width: _kSidebarWidth,
+      height: double.infinity,
+      decoration: BoxDecoration(
+        color: bg,
+        border: Border(right: BorderSide(color: borderColor, width: 1)),
+      ),
+      child: SafeArea(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // ── Header ─────────────────────────────────────────────────
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 18, 16, 12),
+              child: Row(
+                children: [
+                  Image.asset('assets/slash2.png', width: 28, height: 28),
+                  const SizedBox(width: 10),
+                  Text(
+                    '/slash',
+                    style: TextStyle(
+                      fontFamily: 'Inter',
+                      fontSize: 17,
+                      fontWeight: FontWeight.w700,
+                      letterSpacing: -0.4,
+                      color: isDark ? Colors.white : const Color(0xFF111111),
+                    ),
+                  ),
+                  const Spacer(),
+                  GestureDetector(
+                    onTap: onClose,
+                    behavior: HitTestBehavior.opaque,
+                    child: Padding(
+                      padding: const EdgeInsets.all(4),
+                      child: Icon(
+                        Icons.close_rounded,
+                        size: 19,
+                        color:
+                            isDark
+                                ? Colors.white.withValues(alpha: 0.35)
+                                : Colors.black.withValues(alpha: 0.3),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+
+            // Thin separator
+            Divider(
+              color:
+                  isDark
+                      ? Colors.white.withValues(alpha: 0.06)
+                      : Colors.black.withValues(alpha: 0.07),
+              height: 1,
+              indent: 20,
+              endIndent: 20,
+            ),
+            const SizedBox(height: 10),
+
+            // ── Nav items ──────────────────────────────────────────────
+            Expanded(
+              child: ListView(
+                padding: const EdgeInsets.symmetric(horizontal: 12),
+                children: [
+                  for (final feature in navFeatures)
+                    _SidebarItem(
+                      feature: feature,
+                      selected: selectedFeature == feature,
+                      onTap: () => onSelect(feature),
+                      isDark: isDark,
+                    ),
+                ],
+              ),
+            ),
+
+            // ── Settings pinned at bottom ──────────────────────────────
+            if (hasSettings) ...[
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 20),
+                child: Divider(
+                  color:
+                      isDark
+                          ? Colors.white.withValues(alpha: 0.06)
+                          : Colors.black.withValues(alpha: 0.07),
+                  height: 1,
+                ),
+              ),
+              const SizedBox(height: 8),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 12),
+                child: _SidebarItem(
+                  feature: SlashFeature.settings,
+                  selected: selectedFeature == SlashFeature.settings,
+                  onTap: () => onSelect(SlashFeature.settings),
+                  isDark: isDark,
+                ),
+              ),
+              const SizedBox(height: 8),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ── Sidebar item ──────────────────────────────────────────────────────────────
+
+class _SidebarItem extends StatelessWidget {
   final SlashFeature feature;
   final bool selected;
   final VoidCallback onTap;
-  final ThemeData theme;
+  final bool isDark;
 
-  const _NavBarItem({
+  const _SidebarItem({
     required this.feature,
     required this.selected,
     required this.onTap,
-    required this.theme,
+    required this.isDark,
   });
 
   @override
   Widget build(BuildContext context) {
     final meta = kFeatureMeta[feature]!;
-    final hasAsset = meta.assetIcon != null;
+    final primary = const Color(0xFF8B5CF6);
 
-    return Flexible(
-      child: GestureDetector(
-        behavior: HitTestBehavior.opaque,
-        onTap: onTap,
-        child: AnimatedContainer(
-          duration: const Duration(milliseconds: 200),
-          curve: Curves.easeOut,
-          padding: const EdgeInsets.symmetric(vertical: 4),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              AnimatedContainer(
-                duration: const Duration(milliseconds: 200),
-                curve: Curves.easeOut,
-                width: hasAsset ? 50 : 40,
-                height: hasAsset ? 50 : 36,
-                decoration: BoxDecoration(
-                  color:
-                      selected
-                          ? theme.colorScheme.primary.withValues(alpha: 0.12)
-                          : Colors.transparent,
-                  shape: BoxShape.circle,
+    final activeBg =
+        isDark
+            ? const Color(0xFF1A1826)
+            : const Color(0xFFEDE9FE);
+
+    final textColor =
+        selected
+            ? primary
+            : (isDark
+                ? Colors.white.withValues(alpha: 0.72)
+                : const Color(0xFF374151));
+
+    final iconColor =
+        selected
+            ? primary
+            : (isDark
+                ? Colors.white.withValues(alpha: 0.45)
+                : const Color(0xFF6B7280));
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 2),
+      child: Material(
+        color: Colors.transparent,
+        borderRadius: BorderRadius.circular(10),
+        child: InkWell(
+          onTap: onTap,
+          borderRadius: BorderRadius.circular(10),
+          splashColor: primary.withValues(alpha: 0.08),
+          highlightColor: primary.withValues(alpha: 0.04),
+          child: AnimatedContainer(
+            duration: const Duration(milliseconds: 200),
+            curve: Curves.easeOut,
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+            decoration: BoxDecoration(
+              color: selected ? activeBg : Colors.transparent,
+              borderRadius: BorderRadius.circular(10),
+            ),
+            child: Row(
+              children: [
+                // Purple accent bar on the left when selected
+                AnimatedContainer(
+                  duration: const Duration(milliseconds: 200),
+                  width: 3,
+                  height: 17,
+                  margin: const EdgeInsets.only(right: 10),
+                  decoration: BoxDecoration(
+                    color: selected ? primary : Colors.transparent,
+                    borderRadius: BorderRadius.circular(2),
+                  ),
                 ),
-                child:
-                    hasAsset
-                        ? Center(
-                          child: Image.asset(
+                // Icon
+                SizedBox(
+                  width: 20,
+                  height: 20,
+                  child:
+                      meta.assetIcon != null
+                          ? Image.asset(
                             meta.assetIcon!,
-                            width: 80,
-                            height: 80,
-                            fit: BoxFit.contain,
-                            color:
-                                selected
-                                    ? theme.colorScheme.primary
-                                    : theme.colorScheme.onSurface.withValues(
-                                      alpha: 0.7,
-                                    ),
-                          ),
-                        )
-                        : Icon(
-                          meta.icon,
-                          size: 24,
-                          color:
-                              selected
-                                  ? theme.colorScheme.primary
-                                  : theme.colorScheme.onSurface.withValues(
-                                    alpha: 0.7,
-                                  ),
-                        ),
-              ),
-              const SizedBox(height: 2),
-              if (selected && !hasAsset)
-                SlashText(
-                  meta.label,
-                  fontWeight: FontWeight.bold,
-                  fontSize: 12,
-                  color: theme.colorScheme.primary,
+                            width: 20,
+                            height: 20,
+                            color: iconColor,
+                          )
+                          : Icon(meta.icon, size: 18, color: iconColor),
                 ),
-            ],
+                const SizedBox(width: 12),
+                // Label
+                Expanded(
+                  child: Text(
+                    meta.label,
+                    style: TextStyle(
+                      fontFamily: 'Inter',
+                      fontSize: 14,
+                      fontWeight:
+                          selected ? FontWeight.w600 : FontWeight.w400,
+                      color: textColor,
+                      letterSpacing: -0.1,
+                    ),
+                  ),
+                ),
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/ui/screens/settings_screen.dart
+++ b/lib/ui/screens/settings_screen.dart
@@ -5,6 +5,7 @@ import 'package:url_launcher/url_launcher.dart';
 
 import '../../common/nav_preferences.dart';
 import '../../features/auth/auth_controller.dart';
+import '../../home_shell.dart';
 import '../../features/auth/auth_page.dart';
 import '../../features/repo/repo_controller.dart';
 import '../../services/app_config.dart';
@@ -158,21 +159,11 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
   @override
   Widget build(BuildContext context) {
     final auth = ref.watch(authControllerProvider);
-    final isDark = Theme.of(context).brightness == Brightness.dark;
 
     return Scaffold(
-      backgroundColor:
-          isDark ? const Color(0xFF18181B) : const Color(0xFFF8FAFC),
       appBar: AppBar(
-        backgroundColor: isDark ? const Color(0xFF23232A) : Colors.white,
-        elevation: 1,
-        title: Row(
-          children: [
-            Image.asset('assets/slash2.png', height: 36),
-            const SizedBox(width: 12),
-            const SlashText('Settings', fontWeight: FontWeight.bold),
-          ],
-        ),
+        leading: const SidebarMenuButton(),
+        title: const SlashText('Settings', fontWeight: FontWeight.bold),
         actions: [
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
@@ -390,10 +381,8 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     required String title,
     required Widget child,
   }) {
-    final isDark = Theme.of(context).brightness == Brightness.dark;
     return Card(
-      color: isDark ? const Color(0xFF23232A) : Colors.white,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
       elevation: 0,
       child: Padding(
         padding: const EdgeInsets.all(16),
@@ -572,7 +561,6 @@ class _NavFeaturesCard extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final auth = ref.watch(authControllerProvider);
-    final isDark = Theme.of(context).brightness == Brightness.dark;
     final prefs = ref.watch(navPreferencesProvider);
     final pickable =
         SlashFeature.values
@@ -580,8 +568,7 @@ class _NavFeaturesCard extends ConsumerWidget {
             .toList();
 
     return Card(
-      color: isDark ? const Color(0xFF23232A) : Colors.white,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
       elevation: 0,
       child: Padding(
         padding: const EdgeInsets.all(16),
@@ -600,7 +587,7 @@ class _NavFeaturesCard extends ConsumerWidget {
             ),
             const SizedBox(height: 4),
             SlashText(
-              'Choose which features appear on your bottom nav bar.',
+              'Choose which features appear in the sidebar.',
               fontSize: 12,
               color: Theme.of(
                 context,

--- a/lib/ui/theme/app_theme.dart
+++ b/lib/ui/theme/app_theme.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'colors.dart';
 import 'app_colors.dart';
+import 'typography.dart';
 
 class AppTheme {
   final AppColors colors;
@@ -41,20 +42,38 @@ class AppTheme {
   }
 
   static ThemeData buildAppTheme(Brightness brightness) {
-    final colorScheme = ColorScheme.fromSeed(
+    final isDark = brightness == Brightness.dark;
+
+    // Build a base color scheme then override surface colors so the app
+    // feels like a clean AI tool rather than a tinted Material app.
+    final baseScheme = ColorScheme.fromSeed(
       seedColor: SlashColors.primary,
       brightness: brightness,
     );
-
-    final base = ThemeData(
-      brightness: brightness,
-      colorScheme: colorScheme,
-      fontFamily: "DMSans",
-      useMaterial3: true,
+    final colorScheme = baseScheme.copyWith(
+      surface: isDark ? const Color(0xFF0C0C10) : const Color(0xFFF8FAFC),
+      surfaceContainer:
+          isDark ? const Color(0xFF131318) : const Color(0xFFFFFFFF),
+      surfaceContainerHighest:
+          isDark ? const Color(0xFF1E1E28) : const Color(0xFFF1F5F9),
+      onSurface: isDark ? const Color(0xFFF0F0F5) : const Color(0xFF111827),
+      onSurfaceVariant:
+          isDark ? const Color(0xFF9A9AB0) : const Color(0xFF6B7280),
+      outline:
+          isDark
+              ? const Color(0xFF2A2A38)
+              : const Color(0xFFE5E7EB),
     );
 
-    return base.copyWith(
+    return ThemeData(
+      brightness: brightness,
+      colorScheme: colorScheme,
+      useMaterial3: true,
+      fontFamily: 'Inter',
+      textTheme: SlashTypography.textTheme(isDark),
       scaffoldBackgroundColor: colorScheme.surface,
+
+      // ── AppBar ──────────────────────────────────────────────────────────
       appBarTheme: AppBarTheme(
         backgroundColor: colorScheme.surface,
         foregroundColor: colorScheme.onSurface,
@@ -62,15 +81,269 @@ class AppTheme {
         scrolledUnderElevation: 0,
         centerTitle: false,
         surfaceTintColor: Colors.transparent,
+        iconTheme: IconThemeData(
+          color: colorScheme.onSurface.withValues(alpha: 0.75),
+          size: 22,
+        ),
+        titleTextStyle: TextStyle(
+          fontFamily: 'Inter',
+          fontSize: 16,
+          fontWeight: FontWeight.w600,
+          letterSpacing: -0.3,
+          color: colorScheme.onSurface,
+        ),
       ),
+
+      // ── Buttons ─────────────────────────────────────────────────────────
       elevatedButtonTheme: ElevatedButtonThemeData(
         style: ElevatedButton.styleFrom(
+          backgroundColor: SlashColors.primary,
+          foregroundColor: Colors.white,
+          elevation: 0,
+          shadowColor: Colors.transparent,
           shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(12),
+            borderRadius: BorderRadius.circular(10),
           ),
-          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
-          textStyle: const TextStyle(fontWeight: FontWeight.w600),
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+          textStyle: const TextStyle(
+            fontFamily: 'Inter',
+            fontWeight: FontWeight.w600,
+            fontSize: 14,
+            letterSpacing: -0.1,
+          ),
           minimumSize: const Size(44, 40),
+        ),
+      ),
+
+      outlinedButtonTheme: OutlinedButtonThemeData(
+        style: OutlinedButton.styleFrom(
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(10),
+          ),
+          side: BorderSide(
+            color:
+                isDark
+                    ? Colors.white.withValues(alpha: 0.14)
+                    : const Color(0xFFD1D5DB),
+          ),
+          foregroundColor: colorScheme.onSurface,
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+          textStyle: const TextStyle(
+            fontFamily: 'Inter',
+            fontWeight: FontWeight.w500,
+            fontSize: 14,
+          ),
+        ),
+      ),
+
+      textButtonTheme: TextButtonThemeData(
+        style: TextButton.styleFrom(
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(8),
+          ),
+          foregroundColor: SlashColors.primary,
+          textStyle: const TextStyle(
+            fontFamily: 'Inter',
+            fontWeight: FontWeight.w500,
+            fontSize: 14,
+          ),
+        ),
+      ),
+
+      // ── Inputs ──────────────────────────────────────────────────────────
+      inputDecorationTheme: InputDecorationTheme(
+        filled: true,
+        fillColor:
+            isDark ? const Color(0xFF17171F) : const Color(0xFFF9FAFB),
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(10),
+          borderSide: BorderSide(
+            color:
+                isDark
+                    ? Colors.white.withValues(alpha: 0.10)
+                    : const Color(0xFFE5E7EB),
+          ),
+        ),
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(10),
+          borderSide: BorderSide(
+            color:
+                isDark
+                    ? Colors.white.withValues(alpha: 0.10)
+                    : const Color(0xFFE5E7EB),
+          ),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(10),
+          borderSide: const BorderSide(color: SlashColors.primary, width: 1.5),
+        ),
+        errorBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(10),
+          borderSide: const BorderSide(color: SlashColors.error),
+        ),
+        contentPadding: const EdgeInsets.symmetric(
+          horizontal: 14,
+          vertical: 12,
+        ),
+        hintStyle: TextStyle(
+          fontFamily: 'Inter',
+          fontSize: 14,
+          color:
+              isDark
+                  ? Colors.white.withValues(alpha: 0.28)
+                  : const Color(0xFF9CA3AF),
+        ),
+        labelStyle: TextStyle(
+          fontFamily: 'Inter',
+          fontSize: 13,
+          color:
+              isDark
+                  ? Colors.white.withValues(alpha: 0.55)
+                  : const Color(0xFF6B7280),
+        ),
+        helperStyle: TextStyle(
+          fontFamily: 'Inter',
+          fontSize: 12,
+          color:
+              isDark
+                  ? Colors.white.withValues(alpha: 0.4)
+                  : const Color(0xFF9CA3AF),
+        ),
+      ),
+
+      // ── Cards ───────────────────────────────────────────────────────────
+      cardTheme: CardThemeData(
+        elevation: 0,
+        color:
+            isDark ? const Color(0xFF131318) : Colors.white,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(14),
+          side: BorderSide(
+            color:
+                isDark
+                    ? Colors.white.withValues(alpha: 0.07)
+                    : const Color(0xFFE5E7EB),
+          ),
+        ),
+        margin: EdgeInsets.zero,
+      ),
+
+      // ── Chips ───────────────────────────────────────────────────────────
+      chipTheme: ChipThemeData(
+        backgroundColor:
+            isDark ? const Color(0xFF1A1A24) : const Color(0xFFF3F4F6),
+        selectedColor: SlashColors.primary.withValues(alpha: 0.18),
+        disabledColor:
+            isDark
+                ? Colors.white.withValues(alpha: 0.05)
+                : const Color(0xFFF3F4F6),
+        side: BorderSide.none,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+        labelStyle: TextStyle(
+          fontFamily: 'Inter',
+          fontSize: 13,
+          fontWeight: FontWeight.w500,
+          color:
+              isDark ? Colors.white.withValues(alpha: 0.8) : const Color(0xFF374151),
+        ),
+        secondaryLabelStyle: const TextStyle(
+          fontFamily: 'Inter',
+          fontSize: 13,
+          fontWeight: FontWeight.w600,
+          color: SlashColors.primary,
+        ),
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+        elevation: 0,
+        pressElevation: 0,
+      ),
+
+      // ── Divider ─────────────────────────────────────────────────────────
+      dividerTheme: DividerThemeData(
+        color:
+            isDark
+                ? Colors.white.withValues(alpha: 0.07)
+                : const Color(0xFFE5E7EB),
+        thickness: 1,
+        space: 1,
+      ),
+
+      // ── Switch ──────────────────────────────────────────────────────────
+      switchTheme: SwitchThemeData(
+        thumbColor: WidgetStateProperty.resolveWith((states) {
+          if (states.contains(WidgetState.selected)) return Colors.white;
+          return isDark
+              ? Colors.white.withValues(alpha: 0.4)
+              : Colors.grey.shade400;
+        }),
+        trackColor: WidgetStateProperty.resolveWith((states) {
+          if (states.contains(WidgetState.selected)) return SlashColors.primary;
+          return isDark
+              ? Colors.white.withValues(alpha: 0.1)
+              : const Color(0xFFD1D5DB);
+        }),
+        trackOutlineColor: WidgetStateProperty.all(Colors.transparent),
+      ),
+
+      // ── SnackBar ────────────────────────────────────────────────────────
+      snackBarTheme: SnackBarThemeData(
+        backgroundColor:
+            isDark ? const Color(0xFF1E1E28) : const Color(0xFF1F2937),
+        contentTextStyle: const TextStyle(
+          fontFamily: 'Inter',
+          fontSize: 13,
+          color: Colors.white,
+        ),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+        behavior: SnackBarBehavior.floating,
+        elevation: 0,
+      ),
+
+      // ── Dialog ──────────────────────────────────────────────────────────
+      dialogTheme: DialogThemeData(
+        backgroundColor:
+            isDark ? const Color(0xFF16161E) : Colors.white,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+        elevation: 0,
+        titleTextStyle: TextStyle(
+          fontFamily: 'Inter',
+          fontSize: 17,
+          fontWeight: FontWeight.w600,
+          letterSpacing: -0.2,
+          color: isDark ? Colors.white : const Color(0xFF111111),
+        ),
+        contentTextStyle: TextStyle(
+          fontFamily: 'Inter',
+          fontSize: 14,
+          color:
+              isDark
+                  ? Colors.white.withValues(alpha: 0.7)
+                  : const Color(0xFF374151),
+        ),
+      ),
+
+      // ── Bottom sheet ────────────────────────────────────────────────────
+      bottomSheetTheme: BottomSheetThemeData(
+        backgroundColor:
+            isDark ? const Color(0xFF13131A) : Colors.white,
+        shape: const RoundedRectangleBorder(
+          borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+        ),
+        elevation: 0,
+        dragHandleColor:
+            isDark
+                ? Colors.white.withValues(alpha: 0.2)
+                : Colors.black.withValues(alpha: 0.15),
+      ),
+
+      // ── List tile ───────────────────────────────────────────────────────
+      listTileTheme: ListTileThemeData(
+        contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 2),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+        titleTextStyle: TextStyle(
+          fontFamily: 'Inter',
+          fontSize: 14,
+          fontWeight: FontWeight.w500,
+          color: colorScheme.onSurface,
         ),
       ),
     );


### PR DESCRIPTION
- Rewrites HomeShell to use a custom animated slide-in sidebar (280px) instead of a bottom navigation bar; supports swipe-to-open/close gesture
- Adds SidebarMenuButton widget + sidebarOpenSignalProvider so any page can trigger the sidebar from its AppBar leading slot
- Wires SidebarMenuButton into all main page AppBars (Prompt, Code, Ops, Project, PRs, Settings)
- Overhauls AppTheme: Inter font throughout, custom dark/light surface colors (#0C0C10 base), flat inputs with subtle borders, borderless chips, elevation-free cards with 1px border, modern dialogs and snackbars
- Removes hardcoded Material colors from SettingsScreen; updates "bottom nav bar" copy to "sidebar"